### PR TITLE
Added lookup for Ubuntu codename.

### DIFF
--- a/setup.yml
+++ b/setup.yml
@@ -5,7 +5,7 @@
 
   - name: Install needed repositories (apt)
     vars:
-      ubuntu_codename: disco
+      ubuntu_codename: "{{ lookup('pipe', 'lsb_release -cs') }}"
     block:
       - name: Add System76 Pop PPA
         apt_repository:


### PR DESCRIPTION
With the release of Ubuntu 19.10, I'd like to be able to not have to modify the desktop setup playbook based on version. So, I've modified the variable to do a lookup against `lsb_release`.

I don't know how to get _just_ the version number on Fedora. I've opened up #6 to deal with this in the future.